### PR TITLE
feat: Remove page Title

### DIFF
--- a/docs/pre-build.js
+++ b/docs/pre-build.js
@@ -72,8 +72,6 @@ import schema from '../../../../api/${path}';
 import {jsonData} from '../../utils';
 export const json = jsonData(schema, 'docs/pre-build.js');
 
-# ${schema.title}
-
 <PropertyTable schema={schema}/>
 `
                 );

--- a/docs/src/pages/components/actionable.mdx
+++ b/docs/src/pages/components/actionable.mdx
@@ -4,8 +4,6 @@ import schema from '../../../../api/components/actionable.schema.json';
 import {jsonData} from '../../utils';
 export const json = jsonData(schema);
 
-# {schema.title}
-
 This component makes its child actionable based on the defined properties.
 
 When stacking two or more actionables of the same size and using the same attribute, only the lowest one in the tree will be called.

--- a/docs/src/pages/components/button.mdx
+++ b/docs/src/pages/components/button.mdx
@@ -4,8 +4,6 @@ import schema from '../../../../api/components/button.schema.json';
 import {jsonData} from '../../utils';
 export const json = jsonData(schema);
 
-# {schema.title}
-
 This is the button component.
 
 You can set its text, disable it, adjust its size and style, react to a click and add left or right icons.

--- a/docs/src/pages/components/checkbox.mdx
+++ b/docs/src/pages/components/checkbox.mdx
@@ -4,8 +4,6 @@ import schema from '../../../../api/components/checkbox.schema.json';
 import {jsonData} from '../../utils';
 export const json = jsonData(schema);
 
-# {schema.title}
-
 This component provides a toggleable checkbox with several presentation options.
 
 ## Examples

--- a/docs/src/pages/components/container.mdx
+++ b/docs/src/pages/components/container.mdx
@@ -4,8 +4,6 @@ import schema from '../../../../api/components/container.schema.json';
 import {jsonData} from '../../utils';
 export const json = jsonData(schema);
 
-# {schema.title}
-
 The container component that can be used to apply border, padding, constraints or decoration to its child.
 
 ## Examples

--- a/docs/src/pages/components/dropdownButton.mdx
+++ b/docs/src/pages/components/dropdownButton.mdx
@@ -4,8 +4,6 @@ import schema from '../../../../api/components/dropdownButton.schema.json';
 import {jsonData} from '../../utils';
 export const json = jsonData(schema);
 
-# {schema.title}
-
 A dropdown button that can be used to open a dropdown menu when clicked.
 
 ## Examples

--- a/docs/src/pages/components/flex.mdx
+++ b/docs/src/pages/components/flex.mdx
@@ -4,8 +4,6 @@ import schema from '../../../../api/components/flex.schema.json';
 import {jsonData} from '../../utils';
 export const json = jsonData(schema);
 
-# {schema.title}
-
 The Flex component is a container that displays its children in a row or column.
 
 ## Examples

--- a/docs/src/pages/components/flexible.mdx
+++ b/docs/src/pages/components/flexible.mdx
@@ -4,8 +4,6 @@ import schema from '../../../../api/components/flexible.schema.json';
 import {jsonData} from '../../utils';
 export const json = jsonData(schema);
 
-# {schema.title}
-
 The Flexible component can be used to define the way in which its child flexes.
 
 ## Examples

--- a/docs/src/pages/components/form.mdx
+++ b/docs/src/pages/components/form.mdx
@@ -4,8 +4,6 @@ import schema from '../../../../api/components/form.schema.json';
 import {jsonData} from '../../utils';
 export const json = jsonData(schema);
 
-# {schema.title}
-
 The Form component is a container that dispatches an event with all its containing field values.
 
 ## Examples

--- a/docs/src/pages/components/icon.mdx
+++ b/docs/src/pages/components/icon.mdx
@@ -4,8 +4,6 @@ import schema from '../../../../api/components/icon.schema.json';
 import {jsonData} from '../../utils';
 export const json = jsonData(schema);
 
-# {schema.title}
-
 All of the possible values for the icon come from the [material design icons](https://api.flutter.dev/flutter/material/Icons-class.html#constants).
 
 ## Examples

--- a/docs/src/pages/components/image.mdx
+++ b/docs/src/pages/components/image.mdx
@@ -4,8 +4,6 @@ import schema from '../../../../api/components/image.schema.json';
 import {jsonData} from '../../utils';
 export const json = jsonData(schema);
 
-# {schema.title}
-
 This component can be used to load an image online or directly from the application.
 
 ## Examples

--- a/docs/src/pages/components/menu.mdx
+++ b/docs/src/pages/components/menu.mdx
@@ -4,8 +4,6 @@ import schema from '../../../../api/components/menu.schema.json';
 import {jsonData} from '../../utils';
 export const json = jsonData(schema);
 
-# {schema.title}
-
 This component is meant to be used along with the `menuItem` component because there is no real interest of using it alone.
 
 ## Examples

--- a/docs/src/pages/components/menuItem.mdx
+++ b/docs/src/pages/components/menuItem.mdx
@@ -4,8 +4,6 @@ import schema from '../../../../api/components/menuItem.schema.json';
 import {jsonData} from '../../utils';
 export const json = jsonData(schema);
 
-# {schema.title}
-
 This component is made to be used with the `menu` component. This will ensure that the styling is correct and that the menu items are properly sized.
 
 ## Examples

--- a/docs/src/pages/components/overlayEntry.mdx
+++ b/docs/src/pages/components/overlayEntry.mdx
@@ -4,8 +4,6 @@ import schema from '../../../../api/components/overlayEntry.schema.json';
 import {jsonData} from '../../utils';
 export const json = jsonData(schema);
 
-# {schema.title}
-
 This component is used to create an **overlay** that shows itself over the current application's UI. For example, it might be interesting to use it when displaying errors in a snackbar.
 
 ## Examples

--- a/docs/src/pages/components/radio.mdx
+++ b/docs/src/pages/components/radio.mdx
@@ -4,8 +4,6 @@ import schema from '../../../../api/components/radio.schema.json';
 import {jsonData} from '../../utils';
 export const json = jsonData(schema);
 
-# {schema.title}
-
 This component is basically a radio component as you might know it from other frameworks.
 
 ## Examples

--- a/docs/src/pages/components/slider.mdx
+++ b/docs/src/pages/components/slider.mdx
@@ -4,8 +4,6 @@ import schema from '../../../../api/components/slider.schema.json';
 import {jsonData} from '../../utils';
 export const json = jsonData(schema);
 
-# {schema.title}
-
 The slider component can be used to select from a **range** of values.
 
 A certain amount of **divisions** can be set for the slider using the `divisions` property. Then, the `min` and `max` properties need to be set to define the values of the slider. For example, in the case of a slider ranging from **1 to 10** the number of divisions would be 10 and the **min** and **max** properties would be respectively set to 1 and 10.

--- a/docs/src/pages/components/stack.mdx
+++ b/docs/src/pages/components/stack.mdx
@@ -4,8 +4,6 @@ import schema from '../../../../api/components/stack.schema.json';
 import {jsonData} from '../../utils';
 export const json = jsonData(schema);
 
-# {schema.title}
-
 This component is used to make its children overlap. This is particularly interesting when building complex views that needs to put some content above an image or for styling some views.
 The first child in the list will be in the background while the last child of the list will be in the foreground of the stack.
 

--- a/docs/src/pages/components/statusSticker.mdx
+++ b/docs/src/pages/components/statusSticker.mdx
@@ -4,8 +4,6 @@ import schema from '../../../../api/components/statusSticker.schema.json';
 import {jsonData} from '../../utils';
 export const json = jsonData(schema);
 
-# {schema.title}
-
 This component is a status based sticker. It can take 4 different statuses, `success`, `warning`, `error` and `pending`
 
 ## Examples

--- a/docs/src/pages/components/text.mdx
+++ b/docs/src/pages/components/text.mdx
@@ -4,8 +4,6 @@ import schema from '../../../../api/components/text.schema.json';
 import {jsonData} from '../../utils';
 export const json = jsonData(schema);
 
-# {schema.title}
-
 This is a typical text component.
 
 This component has a `children` property in case some complex text needs to be done (see examples below).

--- a/docs/src/pages/components/textfield.mdx
+++ b/docs/src/pages/components/textfield.mdx
@@ -4,8 +4,6 @@ import schema from '../../../../api/components/textfield.schema.json';
 import {jsonData} from '../../utils';
 export const json = jsonData(schema);
 
-# {schema.title}
-
 This component gives the possibility to the user to write text.
 
 ## Examples

--- a/docs/src/pages/components/toggle.mdx
+++ b/docs/src/pages/components/toggle.mdx
@@ -4,8 +4,6 @@ import schema from '../../../../api/components/toggle.schema.json';
 import {jsonData} from '../../utils';
 export const json = jsonData(schema);
 
-# {schema.title}
-
 This component can be toggled on or off.
 
 ## Examples

--- a/docs/src/pages/components/view.mdx
+++ b/docs/src/pages/components/view.mdx
@@ -4,8 +4,6 @@ import schema from '../../../../api/components/view.schema.json';
 import {jsonData} from '../../utils';
 export const json = jsonData(schema);
 
-# {schema.title}
-
 This component calls a view defined in the application. This can be used to create reusable views across the application and call them from anywhere.
 
 The view must be defined and references in the index.js root file of the application.

--- a/docs/src/pages/components/wrap.mdx
+++ b/docs/src/pages/components/wrap.mdx
@@ -4,8 +4,6 @@ import schema from '../../../../api/components/wrap.schema.json';
 import {jsonData} from '../../utils';
 export const json = jsonData(schema);
 
-# {schema.title}
-
 This component can be used to display a long list of components, if they get out of the screen the wrap component will make the overflowing ones use a new row.
 
 ## Examples

--- a/docs/src/pages/index.mdx
+++ b/docs/src/pages/index.mdx
@@ -2,8 +2,6 @@ export const json = {
     "title": "Components API"
 }
 
-# {json.title}
-
 The Lenra's Components API describes the possible component JSON data managed by the Lenra's client to display app UI.
 
 This API is described by a JSON Schema.


### PR DESCRIPTION
## Description of the changes
The name of the page is now managed by the `name` property, if not, by the `title` property, if not, by the name of the file.
