### PR TITLE
feat: Context is now an object instead of a boolean

### DIFF
--- a/api/components/view.schema.json
+++ b/api/components/view.schema.json
@@ -33,7 +33,8 @@
             "deprecated": true
         },
         "context": {
-            "type": "boolean"
+            "description": "The context projection. This field represents the projection of the context, allowing selective retrieval of specific elements. It is a map that specifies the desired elements to be included in the projection.",
+            "type": "object"
         }
     },
     "required": [


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📜 Use Conventional Commit for your PR name (see https://www.conventionalcommits.org/en/v1.0.0/).
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

<!-- 
Link the related issue
-->
Closes #

## Description of the changes
<!-- 
    Simple description of what changed ?
    This helps the reviewer to understand what happens in your code changes and why.
-->

The context field will be used as a projection for selecting specific elements of the context.
For example if you want to retrieve the `me` field from the context you would set this value to the context projection : 
```json
{"me": true}
```

## Checklist
- [x] I didn't over-scope my PR
- [x] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I did not include breaking changes
- [x] I made my own code-review before requesting one


### I included unit tests that cover my changes
  - [ ] 👍 yes
  - [x] 🙅 no, because they aren't needed
  - [ ] 🙋 no, because I need help


### I added/updated the documentation about my changes

- [ ] 📜 README.md
- [ ] 📕 docs/*.md
- [ ] 📓 docs.lenra.io
- [x] 🙅 no documentation needed


## Technical highlight/advice
<!-- 
    Is there any complex point you want to highlight ?
    Do you need advice on specific point of your code ?
    Tell us here.
-->
