### PR TITLE
feat: allow point on listener name

### DIFF
--- a/api/defs/listener.schema.json
+++ b/api/defs/listener.schema.json
@@ -7,7 +7,7 @@
         "action": {
             "description": "The action name to call",
             "type": "string",
-            "pattern": "^(@lenra:)?[a-zA-Z_$][a-zA-Z_$0-9]*$"
+            "pattern": "^(@lenra:)?[a-zA-Z_$][a-zA-Z_.$0-9]*$"
         },
         "props": {
             "description": "Parameters passed to the listener",


### PR DESCRIPTION
## Description of the changes
We should allow the point "." to the action name.
A bit of context : using my elixir template, the current name of the listener depend of the module/function name.
```elixir
def App.Listeners.Counter do
    defview :increment, _params do
        # Do stuff
    end
end

# The action name is automatically bind to : 
"App.Listeners.Counter.increment"
# in
{"action": "App.Listeners.Counter.increment", props: {})
```

Yes, i can replace all "." by "_" before/after each listener but i see no issue adding the point into the allowed character for the action name.

## Checklist
- [x] I didn't over-scope my PR
- [x] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I did not include breaking changes
- [x] I made my own code-review before requesting one


### I included unit tests that cover my changes
  - [ ] 👍 yes
  - [x] 🙅 no, because they aren't needed
  - [ ] 🙋 no, because I need help


### I added/updated the documentation about my changes

- [ ] 📜 README.md
- [ ] 📕 docs/*.md
- [ ] 📓 docs.lenra.io
- [x] 🙅 no documentation needed
